### PR TITLE
Simplify and correct sentence parsing

### DIFF
--- a/lib/label/description_formatter.rb
+++ b/lib/label/description_formatter.rb
@@ -1,7 +1,7 @@
 module Label
   class DescriptionFormatter
 
-    FIRST_SENTENCE_REGEXP = /(?<first_sentence>([^.]*https?:\/\/[^\s]*\..*\..*)|([^.]*\.))(?<rest>.*)/
+    FIRST_SENTENCE_REGEXP = /(?<first_sentence>.+?(\.\s|\Z))/m
     CHARACTERS_PER_LINE = 90
 
     # Formats a description

--- a/spec/label/description_formatter_spec.rb
+++ b/spec/label/description_formatter_spec.rb
@@ -14,6 +14,11 @@ describe Label::DescriptionFormatter do
       expect(format(description)).to eq "# #{description}"
     end
 
+    it 'ignores dots that do not end a sentence' do
+      description = "Ruby 2.0 is awesome"
+      expect(format(description)).to eq "# #{description}"
+    end
+
     context 'with long descriptions' do
       it 'returns the first sentence (ended by ".") for long descriptions' do
         long_description = "Nokogiri (é\u008B¸) is an HTML, XML, SAX, and Reader "+
@@ -43,7 +48,7 @@ describe Label::DescriptionFormatter do
       it 'returns the first sentence in multiple lines when this is too long' do
         long_description = "\\Unicorn is an HTTP server for Rack applications "+
           "designed to only serve\nfast clients on low-latency, high-bandwidth "+
-          "connections and take\nadvantage of features in Unix/Unix-like kernels."+
+          "connections and take\nadvantage of features in Unix/Unix-like kernels. "+
           "Slow clients should\nonly be served by placing a reverse proxy capable"+
           " of fully buffering\nboth the the request and response in between "+
           "\\Unicorn and slow clients."

--- a/spec/label_spec.rb
+++ b/spec/label_spec.rb
@@ -41,7 +41,7 @@ describe Label do
       allow(subject).to receive(:describe).with("unicorn", nil).and_return(
         "\\Unicorn is an HTTP server for Rack applications "+
         "designed to only serve\nfast clients on low-latency, high-bandwidth "+
-        "connections and take\nadvantage of features in Unix/Unix-like kernels."+
+        "connections and take\nadvantage of features in Unix/Unix-like kernels. "+
         "Slow clients should\nonly be served by placing a reverse proxy capable"+
         " of fully buffering\nboth the the request and response in between "+
         "\\Unicorn and slow clients."


### PR DESCRIPTION
Seen a couple of gems that use version numbers and what not in their gem summaries, such as [simplecov](https://github.com/colszowka/simplecov/blob/master/simplecov.gemspec#L12):

``` ruby
gem.description = %Q{Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage across test suites}
```

This PR simplifies the sentence parsing and fixes the above scenario.
